### PR TITLE
Omit empty Terraform provider block

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,12 +200,6 @@ Important notes:
 - `billing_export_datasets` is mandatory and every dataset entry must include `project_id`, `dataset_id`, and `location`
 - `bigquery_read_datasets` is optional, but every dataset entry must include `project_id`, `dataset_id`, and `location`
 
-> [!WARNING]
-> This Terraform module is not intended for use from another Terraform module.
->
-> If you need to call it from another module, first delete the `providers.tf` file.
->
-> For more information, see [Providers Within Modules](https://developer.hashicorp.com/terraform/language/modules/develop/providers) or contact us.
 
 ## Billing Export Datasets
 

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,1 +1,0 @@
-provider "google" {}


### PR DESCRIPTION
Terraform infers the existence of the default provider configuration because your resources use that provider. An empty provider block made explicit breaks the module if used from another module.

Docs: https://developer.hashicorp.com/terraform/language/modules/develop/providers